### PR TITLE
add a entrypoint in `setup.py`, add pwd to PATH in `__init__.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,10 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=['configparser','tkcolorpicker']
+    install_requires=['configparser','tkcolorpicker'],
+    entry_points = {
+        "gui_scripts": [
+            "fotokilof = src.__main__",
+        ]
+    },
 )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+import sys
+import os.path
+sys.path.insert(1, os.path.dirname(__file__))


### PR DESCRIPTION
This PR adds the `entry_points` configuration to the `setup.py` file in order to make setuptools automatically create a wrapper. The GUI can be started by calling `fotokilof` from anywhere.

I also needed to add the `__init__.py` file to allow the `__main__.py` file to load modules in its directory as the `fotokilof` command can be called from anywhere.