### PR TITLE
Log imagemagick error messages

### DIFF
--- a/fotokilof/magick.py
+++ b/fotokilof/magick.py
@@ -28,6 +28,7 @@ module to run ImageMagick:
 
 import logging
 import os
+import subprocess
 
 import common
 
@@ -51,14 +52,23 @@ def magick(cmd, file_in, file_out, operating_system):
             else:
                 command = "magick "
             command_exec = command + file_in + cmd + file_out
-            module_logger.info("Execute: %s", command_exec)
+            module_logger.info(f"Execute: {command_exec}")
             try:
-                os.system(command_exec)
-            except:
-                module_logger.error("Errot in imagick: %s", command_exec)
+                result_sub = subprocess.run( # Use subprocess.run() instead of os.system()
+                    command_exec,
+                    shell=True,
+                    capture_output=True, # This allows capturing the error message, which makes debugging (for the user) easier and faster
+                    text=True,
+                    check=False
+                )
+                if result_sub.returncode == 0:
+                    result = "OK"
+                else: # Log the imagemagick error message
+                    module_logger.error(f'Error when executing command: "{command_exec}"\nImageMagick error message: "{result_sub.stderr.strip()}"')
+                    result = None
+            except Exception as e: # This 'except' block captures non-imagemagick exceptions (like permission errors)
+                module_logger.error(f'Exception when executing command: "{command_exec}"\nException: "{e}"')
                 result = None
-            else:
-                result = "OK"
         else:
             module_logger.warning("imagick: No file for imagick")
             result = None


### PR DESCRIPTION
This commit uses `subsystem.run()` instead of `os.system()` (in magick.py) for returning imagemagick's error message rather than just logging that _something_ failed. This commit also outputs the error message to the logger and replaces some formatted strings with f-strings.